### PR TITLE
Making it so that ambiguous line plot reach ambiguous estimate 

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -272,6 +272,7 @@ make_segs <- function(.data, vdt = .02, ...){
   for(i in 1:(nrow(segs)-1)){
     if(any(abs(.data$lwr[(segs$stim_start[i]+1):nrow(.data)] - segs$bound_start[i]) < amb_thresh)){
       segs$ambiguous[i] <- TRUE
+      segs$stim_end[i] <- max(which((abs(.data$lwr[(segs$stim_start[i]+1):nrow(.data)] - segs$bound_start[i]) < amb_thresh)==T))+i
     }
   } 
   segs


### PR DESCRIPTION
I added the following line to make_segs function in the second if statement:

`segs$stim_end[i] <- max(which((abs(.data$lwr[(segs$stim_start[i]+1):nrow(.data)] - segs$bound_start[i]) < amb_thresh)==T))+i`

When the function identifies an estimate as ambiguous, the line modifies the value of stim_end to be the row value of the ambiguous estimate instead of the last estimate for which the lwr bound < upr bound of the original estimate as it is now the case. 