### PR TITLE
marginaleffects: use `get_draws()` instead of attributes

### DIFF
--- a/vignettes/viztest_intro.Rmd
+++ b/vignettes/viztest_intro.Rmd
@@ -350,7 +350,7 @@ ap_sim <- avg_predictions(model3,
 The "posterior" attribute of the resulting object has the estimates-by-draws posterior simulation values.  We transpose that matrix and add some column names.  We then pass that to `make_vt_data()` with the argument `type="sim"` and call `viztest()`.  Inferential highest density intervals between $76\%$ and $82\%$ all account for the pairwise tests perfectly.  The $79\%$ HDIs are easiest to evaluate. 
 
 ```{r,echo=T}
-post <- t(attr(ap_sim, "posterior"))
+post <- get_draws(ap_sim, "DxP")
 colnames(post) <- paste0("b", 1:ncol(post))
 post_vt <- make_vt_data(post, type="sim")
 vt_sim <- viztest(post_vt, cifun="hdi", include_zero=FALSE)


### PR DESCRIPTION
As noted [in the `marginaleffects` documentation](https://marginaleffects.com/man/r/predictions.html#value), the object attributes are not considered part of the public API, and are subject to change without warning or deprecation cycle. 

The upcoming version of `marginaleffects` will break your vignette because you call `attr(x, "posterior")`. The idiomatic way to achieve the same result is to call the `get_draws()` function, which is stable, exported, and documented.

This PR adjusts your vignette. 