### PR TITLE
Fixing non attribution to test-level CI of trans argument in plot method

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -610,7 +610,7 @@ plot.viztest <- function(x,
   segs$vbl <- rownames(segs)
   inp$label <- factor(1:nrow(inp), labels=inp$vbl)
   inp <- left_join(inp, segs, by=join_by(vbl))
-  cols <- c("est","lwr","upr","bound_start","bound_end")
+  cols <- c("est","lwr","upr","lwr_add","upr_add","bound_start","bound_end")
   inp[,cols] <- apply(inp[,cols],2,trans)
   if(any(inp$vbl == "zero"))inp <- inp[-which(inp$vbl == "zero"), ]
   if(!make_plot){


### PR DESCRIPTION
I've noticed that the new "add_test_level" argument did not connect with the trans argument in the predicted probability example of the article. I've appended the cols vector to include the lwr_add and upr_add columns.

Previous: 
cols <- c("est","lwr","upr","bound_start","bound_end") 
<img width="1920" height="1075" alt="Screenshot 2025-10-27 at 17 09 23" src="https://github.com/user-attachments/assets/3133f9a5-f12d-4cc8-853d-68978643034b" />

Now: 
cols <- c("est","lwr","upr","lwr_add","upr_add","bound_start","bound_end")
<img width="1913" height="1071" alt="Screenshot 2025-10-27 at 17 09 45" src="https://github.com/user-attachments/assets/b1a639d3-653a-4c9e-bccf-64d4d59f77cd" />

