### PR TITLE
Fixing plot method not working when add_test_level=F

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -610,7 +610,9 @@ plot.viztest <- function(x,
   segs$vbl <- rownames(segs)
   inp$label <- factor(1:nrow(inp), labels=inp$vbl)
   inp <- left_join(inp, segs, by=join_by(vbl))
-  cols <- c("est","lwr","upr","lwr_add","upr_add","bound_start","bound_end")
+  cols <- ifelse(add_test_level,
+                 c("est","lwr","upr","lwr_add","upr_add","bound_start","bound_end"),
+                 c("est","lwr","upr","bound_start","bound_end"))
   inp[,cols] <- apply(inp[,cols],2,trans)
   if(any(inp$vbl == "zero"))inp <- inp[-which(inp$vbl == "zero"), ]
   if(!make_plot){


### PR DESCRIPTION
The previous fix did not account for situations where add_test_level=F by adding an ifelse to the cols assignement.